### PR TITLE
Improve sampling behaviour with samples > 1

### DIFF
--- a/chroma/models/chroma.py
+++ b/chroma/models/chroma.py
@@ -355,6 +355,9 @@ class Chroma(nn.Module):
 
         if protein_init is not None:
             X_unc, C_unc, S_unc = protein_init.to_XCS()
+            X_unc = X_unc.repeat(samples, 1, 1, 1)
+            C_unc = C_unc.repeat(samples, 1)
+            S_unc = S_unc.repeat(samples, 1)
         else:
             X_unc, C_unc, S_unc = self._init_backbones(samples, chain_lengths)
 


### PR DESCRIPTION
This looks like a really great project, thank you for making it!

I encountered some inconveniences when trying to generate a large number of samples with `protein_init` not set to `None` and I thought my fixes might be useful for other people.

First, there is a bug in the code right now that leads to only one sample being generated when `protein_init` is not ` None`, independently of the `samples` parameter. Here I expand `X_unc`, `C_unc` and `S_unc` along the batch dimension before passing them to the model to fix that. Second, since there is no batching during sampling, generating a large number of samples is inconvenient. In this PR  I added a `batch_size` parameter to make it possible to generate a larger number of outputs with one command.