### PR TITLE
Update requirements.txt (loosen transformers library version)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ scikit_learn==1.1.2
 scipy
 torch
 tqdm
-transformers==4.24.0
+transformers>=4.24.0


### PR DESCRIPTION
I had trouble installing the library because the requirements strict transformers==4.24.0 

I tried to deliberately update my transformers library to version 4.46.1 and Chroma functioned normally in my case. 